### PR TITLE
ESLint Configuration

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -50,6 +50,9 @@
 			}
 		],
 
+		// MongoDB uses underscore dangle.
+		"no-underscore-dangle": ["off"],
+
 		/* OPINIONATED RULE CONFIGURATIONS */
 		// Use tabs over spaces.
 		"no-tabs": ["off"],


### PR DESCRIPTION
Allows underscore dangle (mongoDB uses it)